### PR TITLE
[#1] Configure application as a Eureka Discovery Server

### DIFF
--- a/src/main/java/com/david/savetodoeurekaserver/SaveTodoEurekaServerApplication.java
+++ b/src/main/java/com/david/savetodoeurekaserver/SaveTodoEurekaServerApplication.java
@@ -2,8 +2,10 @@ package com.david.savetodoeurekaserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
 
 @SpringBootApplication
+@EnableEurekaServer
 public class SaveTodoEurekaServerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=save-todo-eureka-server

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,9 @@
+spring:
+  application:
+    name: save-todo-eureka-server
+server:
+  port: 8761
+eureka:
+  client:
+    fetch-registry: false
+    register-with-eureka: false


### PR DESCRIPTION
### ✅ What does this PR do?
This PR sets up the application to act as a Eureka Discovery Server. It enables other microservices to register themselves for service discovery.

---

### 📋 Related Issue(s)
Closes #1

---

### 🛠 Changes made
- Renamed application.properties to application.yml
- Added Eureka Server configuation to application.yml

---

### 📸 Screenshots (if applicable)
*N/A for this PR*

---

### 🔎 How to test
1. Start Eureka Server
2. Open http://localhost:8761 in a browser
3. Verify the Eureka dashboard loads successfully

---

### 🧠 Notes
*N/A for this PR*
